### PR TITLE
Ported #962 to C++.

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -91,7 +91,8 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install g++-10 cmake valgrind -y
+        sudo apt-get upgrade
+        sudo apt-get install g++-10 clang-10 cmake valgrind -y
         sudo apt-get install g++-10-multilib -y  # for 32-bit compile
         ./ci/set_gcc_10.sh
 

--- a/erb/v1/cpp03_zone.hpp.erb
+++ b/erb/v1/cpp03_zone.hpp.erb
@@ -10,7 +10,15 @@
 #ifndef MSGPACK_V1_CPP03_ZONE_HPP
 #define MSGPACK_V1_CPP03_ZONE_HPP
 
+#include "msgpack/versioning.hpp"
+#include "msgpack/cpp_config.hpp"
 #include "msgpack/zone_decl.hpp"
+
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include <boost/assert.hpp>
 
 <% GENERATION_LIMIT = 15 %>
 namespace msgpack {
@@ -192,10 +200,11 @@ inline zone::zone(size_t chunk_size) /* throw() */ :m_chunk_size(chunk_size), m_
 
 inline char* zone::get_aligned(char* ptr, size_t align)
 {
+    BOOST_ASSERT(align != 0 && (align & (align - 1)) == 0); // align must be 2^n (n >= 0)
     return
         reinterpret_cast<char*>(
-            reinterpret_cast<size_t>(
-            (ptr + (align - 1))) / align * align);
+            reinterpret_cast<uintptr_t>(ptr + (align - 1)) & ~static_cast<uintptr_t>(align - 1)
+        );
 }
 
 inline void* zone::allocate_align(size_t size, size_t align)

--- a/include/msgpack/sysdep.hpp
+++ b/include/msgpack/sysdep.hpp
@@ -26,6 +26,13 @@
     typedef unsigned __int32 uint32_t;
     typedef signed __int64 int64_t;
     typedef unsigned __int64 uint64_t;
+#   if defined(_WIN64)
+        typedef signed __int64 intptr_t;
+        typedef unsigned __int64 uintptr_t;
+#   else
+        typedef signed __int32 intptr_t;
+        typedef unsigned __int32 uintptr_t;
+#   endif
 #elif defined(_MSC_VER)  // && _MSC_VER >= 1600
 #   include <stdint.h>
 #else

--- a/include/msgpack/v1/detail/cpp03_zone.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone.hpp
@@ -10,7 +10,15 @@
 #ifndef MSGPACK_V1_CPP03_ZONE_HPP
 #define MSGPACK_V1_CPP03_ZONE_HPP
 
+#include "msgpack/versioning.hpp"
+#include "msgpack/cpp_config.hpp"
 #include "msgpack/zone_decl.hpp"
+
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include <boost/assert.hpp>
 
 
 namespace msgpack {
@@ -237,10 +245,11 @@ inline zone::zone(size_t chunk_size) /* throw() */ :m_chunk_size(chunk_size), m_
 
 inline char* zone::get_aligned(char* ptr, size_t align)
 {
+    BOOST_ASSERT(align != 0 && (align & (align - 1)) == 0); // align must be 2^n (n >= 0)
     return
         reinterpret_cast<char*>(
-            reinterpret_cast<size_t>(
-            (ptr + (align - 1))) / align * align);
+            reinterpret_cast<uintptr_t>(ptr + (align - 1)) & ~static_cast<uintptr_t>(align - 1)
+        );
 }
 
 inline void* zone::allocate_align(size_t size, size_t align)

--- a/include/msgpack/v1/detail/cpp11_zone.hpp
+++ b/include/msgpack/v1/detail/cpp11_zone.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <vector>
 
+#include <boost/assert.hpp>
+
 namespace msgpack {
 
 /// @cond
@@ -230,10 +232,11 @@ inline zone::zone(size_t chunk_size) noexcept:m_chunk_size(chunk_size), m_chunk_
 
 inline char* zone::get_aligned(char* ptr, size_t align)
 {
+    BOOST_ASSERT(align != 0 && (align & (align - 1)) == 0); // align must be 2^n (n >= 0)
     return
         reinterpret_cast<char*>(
-            reinterpret_cast<size_t>(
-            (ptr + (align - 1))) / align * align);
+            reinterpret_cast<uintptr_t>(ptr + (align - 1)) & ~static_cast<uintptr_t>(align - 1)
+        );
 }
 
 inline void* zone::allocate_align(size_t size, size_t align)

--- a/test/zone.cpp
+++ b/test/zone.cpp
@@ -8,7 +8,7 @@ BOOST_AUTO_TEST_CASE(allocate_align)
     msgpack::zone z;
     char* start = (char*)z.allocate_align(1);
     BOOST_CHECK_EQUAL(0ul, reinterpret_cast<std::size_t>(start) % sizeof(int));
-    for (std::size_t s = 1; s < sizeof(int); ++s) {
+    for (std::size_t s = 1; s < sizeof(int); s <<= 1) {
         z.allocate_no_align(s);
         char* buf_a = (char*)z.allocate_align(1);
         BOOST_CHECK_EQUAL(0ul, reinterpret_cast<std::size_t>(buf_a) % sizeof(int));
@@ -18,10 +18,10 @@ BOOST_AUTO_TEST_CASE(allocate_align)
 BOOST_AUTO_TEST_CASE(allocate_align_custom)
 {
     msgpack::zone z;
-    for (std::size_t align = 1; align < 64; ++align) {
+    for (std::size_t align = 1; align < 64; align <<= 1) {
         char* start = (char*)z.allocate_align(1, align);
         BOOST_CHECK_EQUAL(0ul, reinterpret_cast<std::size_t>(start) % align);
-        for (std::size_t s = 1; s < align; ++s) {
+        for (std::size_t s = 1; s < align; s <<= 1) {
             z.allocate_no_align(s);
             char* buf_a = (char*)z.allocate_align(1, align);
             BOOST_CHECK_EQUAL(0ul, reinterpret_cast<std::size_t>(buf_a) % align);


### PR DESCRIPTION
Improved alignment calculation logic.
Fixed test for zone.
Now, align parameter must be 2^n (n >=0). e.g. 1,2,4,8,16, ...